### PR TITLE
Clean POM layout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,9 @@ buildNumber.properties
 
 # Exclude maven wrapper
 !/.mvn/wrapper/maven-wrapper.jar
+
+# Exclude IDE files
+*.iml
+.idea/
+*.project
+*.classpath

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+# Maven ignores
 target/
 pom.xml.tag
 pom.xml.releaseBackup
@@ -10,9 +11,3 @@ buildNumber.properties
 
 # Exclude maven wrapper
 !/.mvn/wrapper/maven-wrapper.jar
-
-# Exclude IDE files
-*.iml
-.idea/
-*.project
-*.classpath

--- a/pom.xml
+++ b/pom.xml
@@ -9,6 +9,17 @@
     <version>0.1-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>Starter OOPProject-Template</name>
+
+    <properties>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+
+        <checkstyle.version>7.2</checkstyle.version>
+        <checkstyle.plugin.version>2.17</checkstyle.plugin.version>
+
+        <jacoco-maven-plugin.version>0.7.8</jacoco-maven-plugin.version>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>junit</groupId>
@@ -17,13 +28,7 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-    <properties>
-        <maven.compiler.source>1.5</maven.compiler.source>
-        <maven.compiler.target>1.5</maven.compiler.target>
-        <checkstyle.version>7.2</checkstyle.version>
-        <checkstyle.plugin.version>2.17</checkstyle.plugin.version>
-        <argLine/>
-    </properties>
+
     <build>
         <plugins>
             <plugin>
@@ -38,10 +43,11 @@
                     </dependency>
                 </dependencies>
             </plugin>
+
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.7.8</version>
+                <version>${jacoco-maven-plugin.version}</version>
                 <executions>
                     <execution>
                         <id>default-prepare-agent</id>
@@ -61,23 +67,21 @@
                         <goals>
                             <goal>check</goal>
                         </goals>
-                        <configuration>
-                            <rules>
-                            </rules>
-                        </configuration>
                     </execution>
                 </executions>
             </plugin>
+
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <source>${maven.compiler.source}</source>
+                    <target>${maven.compiler.target}</target>
                 </configuration>
             </plugin>
         </plugins>
     </build>
+
     <reporting>
         <plugins>
             <plugin>
@@ -89,8 +93,8 @@
                 <configuration>
                     <configLocation>TI1216.checkstyle.xml</configLocation>
                 </configuration>
-
             </plugin>
         </plugins>
     </reporting>
+
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -67,6 +67,10 @@
                         <goals>
                             <goal>check</goal>
                         </goals>
+                        <configuration>
+                            <rules>
+                            </rules>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>


### PR DESCRIPTION
## Description
This PR adds a bit of spacing to the POM file and, more importantly, this PR sets the java compiler versions to 1.8 properly.
<!--- Describe your changes in detail -->

## Motivation and Context
I found the properties in the POM were not properly linked to the dependencies (including compiler level).
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
`mvn clean install` has been run to confirm proper installation is possible. This included the tests. Also `mvn site` was run after this. Both runs succeeded.

## Checklist:
- [x] Checkstyle warnings stayed the same/went down in this pull request.
